### PR TITLE
fix: remove type module from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "src",
     "templates"
   ],
-  "type": "module",
   "exports": "./lib/index.js",
   "repository": "api-platform/create-client",
   "homepage": "https://github.com/api-platform/create-client",


### PR DESCRIPTION
We don't want to use fully specified imports (yet).