### PR TITLE
fix: remove hardcoded value in react 'Show' template

### DIFF
--- a/templates/react/components/foo/Show.tsx
+++ b/templates/react/components/foo/Show.tsx
@@ -68,7 +68,7 @@ const ShowView = ({del, deleteError, deleted, error, loading, retrieved: item}: 
                   {{else if embedded}}
                     <Links items={ { href: `/{{{embedded.name}}}/show/${encodeURIComponent(item["{{{name}}}"]["@id"])}`, name: item["{{{name}}}"]["@id"] } }/>
                   {{else}}
-                    {item['{{{name}}}']}retrieved
+                    {item['{{{name}}}']}
                   {{/if}}
                 </td>
               </tr>


### PR DESCRIPTION
While I was testing client-create for React I found an hardcoded value in the template

My entity has the name "MyValue" but showing "MyValueretrieved" as shown in the below screenshot
![image](https://github.com/api-platform/create-client/assets/48998273/e10e7fe0-577d-45f0-83e6-852f1e0de768)

After testing with `testgen.sh`, the result is : 
![image](https://github.com/api-platform/create-client/assets/48998273/1e229996-814e-40c7-8584-21a79b02bdc3)
