### PR TITLE
Bugfix : input dateTime type to be complient with html specifications

### DIFF
--- a/src/generators/BaseGenerator.js
+++ b/src/generators/BaseGenerator.js
@@ -139,7 +139,7 @@ export default class {
         return { type: "time" };
 
       case "http://www.w3.org/2001/XMLSchema#dateTime":
-        return { type: "dateTime" };
+        return { type: "datetime-local" };
 
       default:
         return { type: "text" };


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | None
| License       | MIT
| Doc PR        | Not needed

HTML input type "dateTime" seems not complient with official specifications ? 
I suggest to use "datetime-local" instead.

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/datetime-local
https://www.w3schools.com/tags/att_input_type_datetime-local.asp
